### PR TITLE
Add 'int' type

### DIFF
--- a/src/main/c/bindings.c
+++ b/src/main/c/bindings.c
@@ -1,4 +1,9 @@
+#include <inttypes.h>
 #include <stdio.h>
+
+extern void __eplan_print_int(const int32_t x) {
+   printf("%" PRIi32 "\n", x);
+}
 
 extern void __eplan_print_double(const double x) {
    printf("%f\n", x);

--- a/src/main/cup/parser.cup
+++ b/src/main/cup/parser.cup
@@ -37,6 +37,7 @@ parser code {:
   }
 :};
 
+terminal String LITINT;
 terminal String LITREAL;
 terminal        PLUS, MINUS, TIMES, DIV;
 terminal        LPAREN, RPAREN;
@@ -65,7 +66,8 @@ term ::=
 ;
 
 factor ::=
-  LITREAL:x              {: RESULT = new ExpReal(loc(xxleft,xxright), x); :}
+  LITINT:x               {: RESULT = new ExpInt(loc(xxleft,xxright), x); :}
+| LITREAL:x              {: RESULT = new ExpReal(loc(xxleft,xxright), x); :}
 | MINUS:m factor:x       {: RESULT = new ExpNegate(loc(mxleft,xxright), x); :}
 | LPAREN exp:x RPAREN    {: RESULT = x; :}
 ;

--- a/src/main/java/absyn/ExpInt.java
+++ b/src/main/java/absyn/ExpInt.java
@@ -1,0 +1,33 @@
+package absyn;
+
+import javaslang.collection.Tree;
+import parse.Loc;
+import types.INT;
+import types.Type;
+
+import static org.bytedeco.javacpp.LLVM.*;
+
+public class ExpInt extends Exp {
+
+   public final String value;
+
+   public ExpInt(Loc loc, String value) {
+      super(loc);
+      this.value = value;
+   }
+
+   @Override
+   public Tree.Node<String> toTree() {
+      return Tree.of(annotateType("ExpInt: " + value));
+   }
+
+   @Override
+   protected Type semantic_() {
+      return INT.T;
+   }
+
+   @Override
+   public LLVMValueRef translate(LLVMModuleRef module, LLVMBuilderRef builder) {
+      return LLVMConstIntOfString(LLVMInt32Type(), value, (byte)10);
+   }
+}

--- a/src/main/java/codegen/Generator.java
+++ b/src/main/java/codegen/Generator.java
@@ -4,6 +4,7 @@ import absyn.Exp;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
+import types.INT;
 import types.REAL;
 import types.Type;
 
@@ -86,6 +87,7 @@ public class Generator {
 
    public static void addRuntime(LLVMModuleRef module,
                                  LLVMBuilderRef builder) {
+      addPrototype(module, builder, "__eplan_print_int", LLVMVoidType(), LLVMInt32Type());
       addPrototype(module, builder, "__eplan_print_double", LLVMVoidType(), LLVMDoubleType());
       addPrototype(module, builder, "llvm.pow.f64", LLVMDoubleType(), LLVMDoubleType(), LLVMDoubleType());
    }
@@ -94,6 +96,8 @@ public class Generator {
                                              LLVMBuilderRef builder,
                                              Type t_exp,
                                              LLVMValueRef v_exp) {
+      if (t_exp instanceof INT)
+         return addCall(module, builder, "__eplan_print_int", v_exp);
       if (t_exp instanceof REAL) {
          return addCall(module, builder, "__eplan_print_double", v_exp);
       }

--- a/src/main/java/semantic/SemanticHelper.java
+++ b/src/main/java/semantic/SemanticHelper.java
@@ -1,6 +1,8 @@
 package semantic;
 
 import error.CompilerError;
+import static org.bytedeco.javacpp.LLVM.*;
+
 import parse.Loc;
 import types.Type;
 
@@ -18,6 +20,10 @@ public interface SemanticHelper {
          }
       }
       return new CompilerError(loc, "type mismatch: found %s but expected %s", found, builder);
+   }
+
+   static LLVMValueRef int2real(LLVMBuilderRef builder, LLVMValueRef value) {
+      return LLVMBuildSIToFP(builder, value, LLVMDoubleType(), "tmpcast");
    }
 
 }

--- a/src/main/java/types/INT.java
+++ b/src/main/java/types/INT.java
@@ -1,0 +1,14 @@
+package types;
+
+public class INT extends Type {
+
+   public static final INT T = new INT();
+
+   private INT() {
+   }
+
+   @Override
+   public String toString() {
+      return "int";
+   }
+}

--- a/src/main/jflex/lexer.jflex
+++ b/src/main/jflex/lexer.jflex
@@ -70,6 +70,7 @@ litreal   = {litint} | {litfloat1} | {litfloat2} | {litfloat3}
 
 [ \t\f\n\r]+         { /* skip */ }
 
+{litint}             { return tok(LITINT, yytext()); }
 {litreal}            { return tok(LITREAL, yytext()); }
 
 "+"                  { return tok(PLUS); }


### PR DESCRIPTION
- Add type representation for integers
- Add AST for integer constants including semantic analysis and translation to LLVM IR
- Modify semantic analysis and translation to LLVM IR of negation (unary minus) and binary arithmetic expressions. These operators are now overloaded to operate on all numeric types (integers and reals)
- Add a function to print integers in the runtime library
- Add non terminal for integer literals
- Add production rule for integer literals